### PR TITLE
Set exit status to 1 when failing

### DIFF
--- a/bin/copy_to_clipboard
+++ b/bin/copy_to_clipboard
@@ -7,7 +7,7 @@ end
 def red(text); colorize(text, 31); end
 def green(text); colorize(text, 32); end
 
-file_paht = ARGV[0]
+file_path = ARGV[0]
 
 abort(red('You should pass a file as parameter!')) if ARGV.empty?
 abort(red("File doesn't exist!")) unless File.exist?(file_path)

--- a/bin/copy_to_clipboard
+++ b/bin/copy_to_clipboard
@@ -7,17 +7,12 @@ end
 def red(text); colorize(text, 31); end
 def green(text); colorize(text, 32); end
 
-if ARGV.empty?
-  puts red('You should pass a file as parameter!')
-  exit
-end
+file_paht = ARGV[0]
 
-unless File.exist? ARGV[0]
-  puts red("File doesn't exist!")
-  exit
-end
+abort(red('You should pass a file as parameter!')) if ARGV.empty?
+abort(red("File doesn't exist!")) unless File.exist?(file_path)
 
-file = File.open ARGV[0], 'rb'
+file = File.open(file_path, 'rb')
 IO.popen("pbcopy", "w") { |pipe| pipe.puts file.read }
 
 puts green('Content copied! :)')


### PR DESCRIPTION
If you only do:

``` ruby
puts red('You should pass a file as parameter!')
exit
```

The OS won't know that an error occurred because the default exit status is 0.

[abort](https://apidock.com/ruby/Kernel/abort) sets the exit status to 1 and prints the message.